### PR TITLE
update vim-go settings

### DIFF
--- a/lua/user/vim-go.lua
+++ b/lua/user/vim-go.lua
@@ -3,7 +3,7 @@ local M = {
 }
 
 function M.config()
-  vim.cmd.GoUpdateBinaries()
+  -- vim.cmd.GoUpdateBinaries()
 end
 
 return M


### PR DESCRIPTION
update vim-go settings to prevent auto-update on every nvim launch